### PR TITLE
fix(buttons): update sm buttons style

### DIFF
--- a/src/css/postmark/buttons.css
+++ b/src/css/postmark/buttons.css
@@ -27,6 +27,7 @@
 
 @screen sm {
   .button {
+    @apply box-border;
     @apply w-full text-center !important;
   }
 }

--- a/src/css/postmark/buttons.css
+++ b/src/css/postmark/buttons.css
@@ -27,7 +27,6 @@
 
 @screen sm {
   .button {
-    @apply box-border;
-    @apply w-full text-center !important;
+    @apply block text-center !important;
   }
 }


### PR DESCRIPTION
Currently, in sm mode, the buttons are wider than the body.

Applying `box-sizing: border-box;` fixes the issue globally.